### PR TITLE
now prints unicode chars when dumping the yaml

### DIFF
--- a/lookatme/__main__.py
+++ b/lookatme/__main__.py
@@ -7,6 +7,7 @@ This is the main CLI for lookatme
 
 import click
 import logging
+import io
 import os
 import pygments.styles
 import sys
@@ -56,8 +57,12 @@ from lookatme.schemas import StyleSchema
     is_flag=True,
     default=False,
 )
-@click.argument("input_file", type=click.File(), default=sys.stdin)
-def main(debug, log_path, theme, code_style, dump_styles, input_file, live_reload):
+@click.argument(
+    "input_files",
+    type=click.File("r"),
+    nargs=-1,
+)
+def main(debug, log_path, theme, code_style, dump_styles, input_files, live_reload):
     """lookatme - An interactive, terminal-based markdown presentation tool.
     """
     if debug:
@@ -65,7 +70,9 @@ def main(debug, log_path, theme, code_style, dump_styles, input_file, live_reloa
     else:
         lookatme.config.LOG = lookatme.log.create_null_log()
 
-    pres = Presentation(input_file, theme, code_style, live_reload=live_reload)
+    if len(input_files) == 0:
+        input_files = [io.StringIO("")]
+    pres = Presentation(input_files[0], theme, code_style, live_reload=live_reload)
 
     if dump_styles:
         print(StyleSchema().dumps(pres.styles))

--- a/lookatme/schemas.py
+++ b/lookatme/schemas.py
@@ -33,7 +33,7 @@ NoDatesSafeLoader.remove_implicit_resolver('tag:yaml.org,2002:timestamp')
 
 class YamlRender:
     loads = lambda data: yaml.load(data, Loader=NoDatesSafeLoader)
-    dumps = lambda data: yaml.safe_dump(data)
+    dumps = lambda data: yaml.safe_dump(data, allow_unicode=True)
 
 
 class BulletsSchema(Schema):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+"""
+Test the main CLI
+"""
+
+
+from click.testing import CliRunner
+
+
+from lookatme.__main__ import main
+
+
+def run_cmd(*args):
+    """Run the provided arguments
+    """
+    runner = CliRunner()
+    return runner.invoke(main, args)
+
+
+def test_dump_styles_unicode():
+    """Test that dump styles works correctly
+    """
+    res = run_cmd("--dump-styles")
+    assert res.exit_code == 0
+    assert "█" in res.output


### PR DESCRIPTION
fixes #53 

```
$> python -m lookatme test.md --dump-styles
bullets:
  '1': •
  '2': ⁃
  '3': ◦
  default: •
headings:
  '1':
    bg: default
    fg: '#9fc,bold'
    prefix: '██ '
    suffix: ''
  '2':
    bg: default
    fg: '#1cc,bold'
    prefix: '▓▓▓ '
    suffix: ''
  '3':
    bg: default
    fg: '#29c,bold'
    prefix: '▒▒▒▒ '
    suffix: ''
  '4':
    bg: default
    fg: '#559,bold'
    prefix: '░░░░░ '
    suffix: ''
  default:
    bg: default
    fg: '#346,bold'
    prefix: '░░░░░ '
    suffix: ''
link:
  bg: default
  fg: '#33c,underline'
quote:
  bottom_corner: └
  side: ╎
  style:
    bg: default
    fg: italics,#aaa
  top_corner: ┌
style: monokai
table:
  column_spacing: 3
  header_divider: ─
```