### PR TITLE
Adds -e|--exts|LOOKATME_EXTS

### DIFF
--- a/lookatme/__main__.py
+++ b/lookatme/__main__.py
@@ -59,6 +59,15 @@ from lookatme.schemas import StyleSchema
     default=False,
 )
 @click.option(
+    "-e",
+    "--exts",
+    "extensions",
+    help="A comma-separated list of extension names to automatically load"
+         " (LOOKATME_EXTS)",
+    envvar="LOOKATME_EXTS",
+    default="",
+)
+@click.option(
     "--single",
     "--one",
     "single_slide",
@@ -72,7 +81,8 @@ from lookatme.schemas import StyleSchema
     type=click.File("r"),
     nargs=-1,
 )
-def main(debug, log_path, theme, code_style, dump_styles, input_files, live_reload, single_slide):
+def main(debug, log_path, theme, code_style, dump_styles,
+         input_files, live_reload, extensions, single_slide):
     """lookatme - An interactive, terminal-based markdown presentation tool.
     """
     if debug:
@@ -82,12 +92,16 @@ def main(debug, log_path, theme, code_style, dump_styles, input_files, live_relo
 
     if len(input_files) == 0:
         input_files = [io.StringIO("")]
+
+    preload_exts = [x.strip() for x in extensions.split(',')]
+    preload_exts = list(filter(lambda x: x != '', preload_exts))
     pres = Presentation(
         input_files[0],
         theme,
         code_style,
         live_reload=live_reload,
-        single_slide=single_slide
+        single_slide=single_slide,
+        preload_extensions=preload_exts,
     )
 
     if dump_styles:

--- a/lookatme/pres.py
+++ b/lookatme/pres.py
@@ -21,12 +21,13 @@ class Presentation(object):
     """Defines a presentation
     """
     def __init__(self, input_stream, theme, style_override=None, live_reload=False,
-                 single_slide=False):
+                 single_slide=False, preload_extensions=None):
         """Creates a new Presentation
 
         :param stream input_stream: An input stream from which to read the
             slide data
         """
+        self.preload_extensions = preload_extensions or []
         self.input_filename = None
         if hasattr(input_stream, "name"):
             lookatme.config.SLIDE_SOURCE_DIR = os.path.dirname(input_stream.name)
@@ -77,7 +78,10 @@ class Presentation(object):
 
         parser = Parser(single_slide=self.single_slide)
         self.meta, self.slides = parser.parse(data)
-        lookatme.contrib.load_contribs(self.meta.get("extensions", []))
+
+        all_exts = set(self.preload_extensions)
+        all_exts |= set(self.meta.get("extensions", []))
+        lookatme.contrib.load_contribs(all_exts)
 
         self.styles = lookatme.themes.ensure_defaults(self.theme_mod)
         dict_deep_update(self.styles, self.meta.get("styles", {}))


### PR DESCRIPTION
Adds methods to pre-load extensions without needing to specify them in the markdown:

Comma-separated list of contrib extension names via:
 
* cmd-line options: `-e|--exts`
* env var `LOOKATME_EXTS`