### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-marshmallow>=3,<4
+marshmallow==3.0.0
 Click>=7,<8
 PyYAML>=5,<6
 mistune>=0.8,<1


### PR DESCRIPTION
#114 shows that this version of marshmallow builds the lookatme binary without errors. Later versions of marshmallow bring a serialization issue. This is a stop-gap fix until lookatme can be modified to work with later versions of marshmallow