### PR TITLE
Makes lookatme compatible with the latest marshmallow version

### DIFF
--- a/lookatme/contrib/file_loader.py
+++ b/lookatme/contrib/file_loader.py
@@ -46,8 +46,8 @@ class FileSchema(Schema):
     transform = fields.Str(default=None, missing=None)
     lines = fields.Nested(
         LineRange,
-        default=LineRange().dump(LineRange()),
-        missing=LineRange().dump(LineRange()),
+        default=LineRange().dump({}),
+        missing=LineRange().dump({})
     )
 
     class Meta:

--- a/lookatme/schemas.py
+++ b/lookatme/schemas.py
@@ -44,13 +44,13 @@ class BulletsSchema(Schema):
             "1": fields.Str(default="•"),
             "2": fields.Str(default="⁃"),
             "3": fields.Str(default="◦"),
-            "4": fields.Str(),
-            "5": fields.Str(),
-            "6": fields.Str(),
-            "7": fields.Str(),
-            "8": fields.Str(),
-            "9": fields.Str(),
-            "10": fields.Str(),
+            "4": fields.Str(default="•"),
+            "5": fields.Str(default="⁃"),
+            "6": fields.Str(default="◦"),
+            "7": fields.Str(default="•"),
+            "8": fields.Str(default="⁃"),
+            "9": fields.Str(default="◦"),
+            "10": fields.Str(default="•"),
         }
 
 _NUMBERING_VALIDATION = validate.OneOf(["numeric", "alpha", "roman"])
@@ -62,13 +62,13 @@ class NumberingSchema(Schema):
             "1": fields.Str(default="numeric", validate=_NUMBERING_VALIDATION),
             "2": fields.Str(default="alpha", validate=_NUMBERING_VALIDATION),
             "3": fields.Str(default="roman", validate=_NUMBERING_VALIDATION),
-            "4": fields.Str(validate=_NUMBERING_VALIDATION),
-            "5": fields.Str(validate=_NUMBERING_VALIDATION),
-            "6": fields.Str(validate=_NUMBERING_VALIDATION),
-            "7": fields.Str(validate=_NUMBERING_VALIDATION),
-            "8": fields.Str(validate=_NUMBERING_VALIDATION),
-            "9": fields.Str(validate=_NUMBERING_VALIDATION),
-            "10": fields.Str(validate=_NUMBERING_VALIDATION),
+            "4": fields.Str(default="numeric", validate=_NUMBERING_VALIDATION),
+            "5": fields.Str(default="alpha", validate=_NUMBERING_VALIDATION),
+            "6": fields.Str(default="roman", validate=_NUMBERING_VALIDATION),
+            "7": fields.Str(default="numeric", validate=_NUMBERING_VALIDATION),
+            "8": fields.Str(default="alpha", validate=_NUMBERING_VALIDATION),
+            "9": fields.Str(default="roman", validate=_NUMBERING_VALIDATION),
+            "10": fields.Str(efault="numeric", validate=_NUMBERING_VALIDATION),
         }
 
 
@@ -193,12 +193,12 @@ class StyleSchema(Schema):
         "right": 10,
     })
 
-    headings = fields.Nested(HeadingsSchema, default=HeadingsSchema().dump(HeadingsSchema()))
-    bullets = fields.Nested(BulletsSchema, default=BulletsSchema().dump(BulletsSchema()))
-    numbering = fields.Nested(NumberingSchema, default=NumberingSchema().dump(NumberingSchema()))
-    table = fields.Nested(TableSchema, default=TableSchema().dump(TableSchema()))
-    quote = fields.Nested(BlockQuoteSchema, default=BlockQuoteSchema().dump(BlockQuoteSchema()))
-    hrule = fields.Nested(HruleSchema, default=HruleSchema().dump(HruleSchema()))
+    headings = fields.Nested(HeadingsSchema, default=HeadingsSchema().dump({}))
+    bullets = fields.Nested(BulletsSchema, default=BulletsSchema().dump({}))
+    numbering = fields.Nested(NumberingSchema, default=NumberingSchema().dump({}))
+    table = fields.Nested(TableSchema, default=TableSchema().dump({}))
+    quote = fields.Nested(BlockQuoteSchema, default=BlockQuoteSchema().dump({}))
+    hrule = fields.Nested(HruleSchema, default=HruleSchema().dump({}))
     link = fields.Nested(StyleFieldSchema, default={
         "fg": "#33c,underline",
         "bg": "default",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-marshmallow>=3,<4
+marshmallow>=3.12.1,<4
 Click>=7,<8
 PyYAML>=5,<6
 mistune>=0.8,<1

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps = -r requirements.txt
     pytest-mock
     pytest-cov
     coveralls
+    six
 whitelist_externals =
     bash
     coveralls


### PR DESCRIPTION
See #114 for a full discussion of this. Simply put, marshmallow changed the behavior of the `dump()` function, and lookatme needed to be updated to be compatible with the latest version of marshmallow.