### PR TITLE
Add support for progressive slides

### DIFF
--- a/examples/progressive.md
+++ b/examples/progressive.md
@@ -8,10 +8,10 @@ With some content.
 
 - This is the first part.
 
-:::
+<!-- stop -->
 
 - And this is the second part.
 
-:::
+<!-- stop -->
 
-- Parts are separated by a `:::` paragraph.
+- Parts are separated by a `<!-- stop -->` paragraph.

--- a/examples/progressive.md
+++ b/examples/progressive.md
@@ -1,0 +1,17 @@
+# This is a normal slide
+
+With some content.
+
+---
+
+# This is a multi-part slide
+
+- This is the first part.
+
+:::
+
+- And this is the second part.
+
+:::
+
+- Parts are separated by a `:::` paragraph.

--- a/lookatme/parser.py
+++ b/lookatme/parser.py
@@ -14,16 +14,13 @@ from lookatme.schemas import MetaSchema
 from lookatme.slide import Slide
 
 
-PROGRESSIVE_SLIDE_DELIMITER = ":::"
-
-
 def is_progressive_slide_delimiter_token(token):
     """Returns True if the token indicates the end of a progressive slide
 
     :param dict token: The markdown token
     :returns: True if the token is a progressive slide delimiter
     """
-    return token["type"] == "paragraph" and token["text"] == PROGRESSIVE_SLIDE_DELIMITER
+    return token["type"] == "close_html" and re.match(r'<!--\s*stop\s*-->', token["text"])
 
 
 class Parser(object):


### PR DESCRIPTION
This PR adds a way to separate a slide into multiple parts and show them progressively. Parts are separated by creating a `:::` line.

Here is an example. This presentation:

```md
# This is a normal slide

With some content.

---

# This is a multi-part slide

- This is the first part.

:::

- And this is the second part.

:::

- Parts are separated by a `:::` paragraph.
```

Looks like this:

![demo](https://user-images.githubusercontent.com/3575/125040877-663f3000-e098-11eb-90b2-2c91f7b9346e.gif)

This feature provides a way to do #80, except numbered list won't work :/

I picked `:::` as the part delimiter because it looks similar to the `---` slide delimiter and I felt it was unlikely to cause conflicts with real content, but I am happy to change it to anything else if you prefer.