### PR TITLE
Resolve conflict between `-s` for `--style` and `-s` for `--safe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
   --debug
   -l, --log PATH
   -t, --theme [dark|light]
-  -s, --style [default|emacs|friendly|colorful|autumn|murphy|manni|monokai|perldoc|pastie|borland|trac|native|fruity|bw|vim|vs|tango|rrt|xcode|igor|paraiso-light|paraiso-dark|lovelace|algol|algol_nu|arduino|rainbow_dash|abap|solarized-dark|solarized-light|sas|stata|stata-light|stata-dark|inkpot]
+  --style [default|emacs|friendly|colorful|autumn|murphy|manni|monokai|perldoc|pastie|borland|trac|native|fruity|bw|vim|vs|tango|rrt|xcode|igor|paraiso-light|paraiso-dark|lovelace|algol|algol_nu|arduino|rainbow_dash|abap|solarized-dark|solarized-light|sas|stata|stata-light|stata-dark|inkpot]
   --dump-styles                   Dump the resolved styles that will be used
                                   with the presentation to stdout
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -30,7 +30,7 @@ The ``lookatme`` CLI has a few options to control it's behavior:
       --debug
       -l, --log PATH
       -t, --theme [dark|light]
-      -s, --style [default|emacs|friendly|colorful|autumn|murphy|manni|monokai|perldoc|pastie|borland|trac|native|fruity|bw|vim|vs|tango|rrt|xcode|igor|paraiso-light|paraiso-dark|lovelace|algol|algol_nu|arduino|rainbow_dash|abap|solarized-dark|solarized-light|sas|stata|stata-light|stata-dark|inkpot]
+      --style [default|emacs|friendly|colorful|autumn|murphy|manni|monokai|perldoc|pastie|borland|trac|native|fruity|bw|vim|vs|tango|rrt|xcode|igor|paraiso-light|paraiso-dark|lovelace|algol|algol_nu|arduino|rainbow_dash|abap|solarized-dark|solarized-light|sas|stata|stata-light|stata-dark|inkpot]
       --dump-styles                   Dump the resolved styles that will be used
                                       with the presentation to stdout
 

--- a/lookatme/__main__.py
+++ b/lookatme/__main__.py
@@ -38,7 +38,6 @@ from lookatme.schemas import StyleSchema
     default="dark",
 )
 @click.option(
-    "-s",
     "--style",
     "code_style",
     default=None,


### PR DESCRIPTION
The `-s` option flag is used for both style and safe options. It seems the last use wins, so remove `-s` for style since it was declared first.

Too bad Click does not complain about that.