### PR TITLE
Adds a new workflow that publishes tags to PyPI

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -16,7 +16,8 @@ jobs:
           if [[ "${{github.ref}}" =~ ^refs/tags/.* ]] ; then
             version_num="${{github.ref_name}}"
           else
-            version_num="v0.0.0-${{github.ref_name}}"
+            local_version_label=$(sed 's/[^a-zA-Z0-9\.]/./g' <<<"${{github.ref_name}}")
+            version_num="v0.0.0+${local_version_label}"
             # amusingly, the lookatme name is taken by someone else on test.pypi!
             sed -i 's/name="lookatme"/name="lookatme-test"/' setup.py
           fi

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -28,6 +28,7 @@ jobs:
           grep -rl '{{VERSION}}' . | xargs sed -i "s/{{VERSION}}/$version_num/g"
           echo "Files with {{VERSION}} after replacing:"
           grep -rl '{{VERSION}}' .
+          true
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build binary wheel + tarball

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
-on: push
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build-and-publish:
@@ -13,14 +16,7 @@ jobs:
           python-version: "3.10"
       - name: Set VERSION number
         run: |
-          if [[ "${{github.ref}}" =~ ^refs/tags/.* ]] ; then
-            version_num="${{github.ref_name}}"
-          else
-            local_version_label=$(sed 's/[^a-zA-Z0-9\.]/./g' <<<"${{github.ref_name}}")
-            version_num="v0.0.0+${local_version_label}"
-            # amusingly, the lookatme name is taken by someone else on test.pypi!
-            sed -i 's/name="lookatme"/name="lookatme-test"/' setup.py
-          fi
+          version_num="${{github.ref_name}}"
           # strip the leading v
           version_num=${version_num#v}
           echo "Replacing {{VERSION}} with '$version_num'"
@@ -39,7 +35,6 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI
-        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -27,8 +27,7 @@ jobs:
           grep -rl '{{VERSION}}' .
           grep -rl '{{VERSION}}' . | xargs sed -i "s/{{VERSION}}/$version_num/g"
           echo "Files with {{VERSION}} after replacing:"
-          grep -rl '{{VERSION}}' .
-          true
+          grep -rl '{{VERSION}}' . || true
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build binary wheel + tarball

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,8 +1,5 @@
 name: Publish to PyPI
-on:
-  push:
-    tags:
-      - 'v*.*.*'
+on: push
 
 jobs:
   build-and-publish:
@@ -16,9 +13,16 @@ jobs:
           python-version: "3.10"
       - name: Set VERSION number
         run: |
-          version_num="${{github.ref_name}}"
+          if [[ "${{github.ref}}" =~ ^refs/tags/.* ]] ; then
+            version_num="${{github.ref_name}}"
+          else
+            version_num="v0.0.0-${{github.ref_name}}"
+            # amusingly, the lookatme name is taken by someone else on test.pypi!
+            sed -i 's/name="lookatme"/name="lookatme-test"/' setup.py
+          fi
           # strip the leading v
           version_num=${version_num#v}
+          echo "Replacing {{VERSION}} with '$version_num'"
           echo "Files with {{VERSION}}:"
           grep -rl '{{VERSION}}' .
           grep -rl '{{VERSION}}' . | xargs sed -i "s/{{VERSION}}/$version_num/g"
@@ -28,7 +32,13 @@ jobs:
         run: python -m pip install build --user
       - name: Build binary wheel + tarball
         run: python -m build --sdist --wheel --outdir dist/
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set VERSION number
+        run: |
+          version_num="${{github.ref_name}}"
+          # strip the leading v
+          version_num=${version_num#v}
+          echo "Files with {{VERSION}}:"
+          grep -rl '{{VERSION}}' .
+          grep -rl '{{VERSION}}' . | xargs sed -i "s/{{VERSION}}/$version_num/g"
+          echo "Files with {{VERSION}} after replacing:"
+          grep -rl '{{VERSION}}' .
+      - name: Install pypa/build
+        run: python -m pip install build --user
+      - name: Build binary wheel + tarball
+        run: python -m build --sdist --wheel --outdir dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
fixes #157 

It should do this when
* The current push is a tag
* The tag name matches `v*.*.*`