### PR TITLE
Fixes the `--single` option with progressive slides

### DIFF
--- a/lookatme/parser.py
+++ b/lookatme/parser.py
@@ -136,14 +136,9 @@ class Parser(object):
         keep_split_token = True
 
         if self._single_slide:
+            return [Slide(tokens, 0)]
 
-            def slide_split_check(_):  # type: ignore
-                return False
-
-            def heading_mod(_):  # type: ignore
-                pass
-
-        elif num_hrules == 0:
+        if num_hrules == 0:
             if meta.get("title", "") in ["", None]:
                 meta["title"] = hinfo["title"]
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -113,6 +113,30 @@ More text
     assert len(slides) == 4
 
 
+def test_parse_slides_with_progressive_stops_and_hrule_splits_and_single_option():
+    """Test that slide parsing works correctly"""
+    input_data = r"""
+# Heading
+
+<!-- stop -->
+
+p1
+
+<!-- stop -->
+
+p2
+
+---
+
+# Slide 2
+
+More text
+    """
+    parser = Parser(single_slide=True)
+    slides = parser.parse_slides({}, input_data)
+    assert len(slides) == 1
+
+
 def test_parse_smart_slides_one_h1():
     """Test that slide smart splitting works correctly"""
     input_data = r"""


### PR DESCRIPTION
See #182. This PR is specifically for the 3.0-dev branch.