### PR TITLE
3.0 - Adds better HTML rendering

### DIFF
--- a/lookatme/output/templates/styles.template.css
+++ b/lookatme/output/templates/styles.template.css
@@ -228,6 +228,7 @@ body {
     top: 0;
     color: #2c2c2c;
     background-color: {{styles.scrollbar.gutter.bg}};
+    user-select: none;
 }
 
 .scrollbar-slider {
@@ -235,6 +236,7 @@ body {
     top: 0;
     z-index: 200;
     color: #4c4c4c;
+    user-select: none;
 }
 
 @keyframes blinker {

--- a/lookatme/render/markdown_inline.py
+++ b/lookatme/render/markdown_inline.py
@@ -307,6 +307,7 @@ def render_code_inline(token, ctx: Context):
 
     for spec, text in markups:
         spec = ctx.spec_text_with(spec)
+        spec.preserve_spaces = True
         ctx.inline_push((spec, text))
 
 

--- a/lookatme/widgets/codeblock.py
+++ b/lookatme/widgets/codeblock.py
@@ -140,6 +140,7 @@ class SyntaxHlStyle:
             )["fg"]
 
         colors.ensure_contrast(spec)
+        spec.preserve_spaces = True
 
         return spec
 

--- a/lookatme/widgets/smart_attr_spec.py
+++ b/lookatme/widgets/smart_attr_spec.py
@@ -2,6 +2,8 @@ import urwid
 
 
 class SmartAttrSpec(urwid.AttrSpec):
+    preserve_spaces: bool = False
+
     def __init__(self, fg, bg):
         """An attr spec that chooses the right color depth"""
         super().__init__(fg, bg, 2**24)

--- a/tests/outputs/test_html_raw.py
+++ b/tests/outputs/test_html_raw.py
@@ -13,10 +13,6 @@ import lookatme.output
 from lookatme.pres import Presentation
 
 
-def htmld(val: str) -> str:
-    return str.replace(val, " ", "&nbsp;")
-
-
 def test_html_raw_output_defined():
     assert "html_raw" in lookatme.output.get_all_formats()
 
@@ -78,9 +74,14 @@ def test_basic_raw_slide_generation(tmpdir):
         with open(file, "r") as f:
             data = f.read()
 
-        assert htmld(f"Slide {idx + 1}") in data
-        assert htmld(f"slide {idx + 1} / {len(html_files)}") in data
+        assert f"Slide {idx + 1}" in data
+        assert f"slide {idx + 1} / {len(html_files)}" in data
 
         assert data.count("<br/>") == rows - 1
         lines = data.split("<br/>")
-        assert lines[1].count("&nbsp;") == cols
+
+        total_spaces = 0
+        for match in re.finditer(r"style='padding-left: (\d+)ch'", lines[1]):
+            total_spaces += int(match.group(1))
+
+        assert total_spaces == cols


### PR DESCRIPTION
This PR changes the default html rendering to use spans with padding set to a specific number of monospace character widths instead of `&nbsp;` for all spaces. This makes the text of the html (especially code snippets) easier to copy+paste.

### Examples

Markdown like this:

~~~markdown
This is markdown

```
 code   block
```
~~~

was originally rendered into this:

```html
<span style="color: #ffffff; background-color: #000000">Test</span>&nbsp;&nbsp;&nbsp; ...
<span style="color: #ffffff; background-color: #000000">&nbsp;&nbsp;&nbsp;&nbsp; ...
<span style="color: #f8f8f2; background-color: #272822">&nbsp;code&nbsp;&nbsp;block</span><span style="background-color: #272822">&nbsp;&nbsp; ...
```

but is now rendered into this:

```html
</span><span style="color: #ffffff; background-color: #000000">Test</span><span style='padding-left: 76ch'></span>
</span><span style="color: #ffffff; background-color: #000000"><span style='padding-left: 80ch'></span></span>
</span><span style="color: #f8f8f2; background-color: #272822">&nbsp;code&nbsp;&nbsp;block</span><span style="background-color: #272822"><span style='padding-left: 68ch'></span></span>
```

Fixes #212 