### PR TITLE
Support all tokens

### DIFF
--- a/bin/fill_placeholders
+++ b/bin/fill_placeholders
@@ -15,7 +15,7 @@ USAGE: $THIS_PROG VERSION_NUMBER
 This script will fill all placeholder values in the lookatme me project.
 Specifically:
 
-* {{VERSION}} will be replaced with the version number (no 'v' prefix!)
+* 0.0.0-rc-dev will be replaced with the version number (no 'v' prefix!)
 * {{LOOKATME_HELP_OUTPUT}} will be replaced with output from  "lookatme --help"
 * {{LOOKATME_HELP_OUTPUT_INDENTED}} will be replaced with the indented
   output of "lookatme --help"
@@ -52,7 +52,7 @@ EOF
 }
 
 function set_version {
-    replace_in_files "{{VERSION}}" "$VERSION"
+    replace_in_files "0.0.0-rc-dev" "$VERSION"
 }
 
 function set_help_output {
@@ -83,6 +83,6 @@ function parse_args {
 }
 
 parse_args "$@"
-# needs to come first, can contain {{VERSION}} placeholders
+# needs to come first, can contain 0.0.0-rc-dev placeholders
 set_help_output
 set_version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,7 +131,7 @@ with open(os.path.join(DOCS_SOURCE_DIR, "contrib_extensions_auto.rst"), "w") as 
 
 
 def run_apidoc(_):
-	from sphinx.ext.apidoc import main
+	from sphinx.ext.apidoc import main  # type: ignore
 	import os
 	import sys
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,7 @@ author = "James 'd0c-s4vage' Johnson"
 
 
 # The full version, including alpha/beta/rc tags
-release = os.environ.get("READTHEDOCS_VERSION", '{{VERSION}}')
+release = os.environ.get("READTHEDOCS_VERSION", '0.0.0-rc-dev')
 
 
 # -- General configuration ---------------------------------------------------

--- a/lookatme/__init__.py
+++ b/lookatme/__init__.py
@@ -1,1 +1,1 @@
-VERSION = __version__ = "{{VERSION}}"
+VERSION = __version__ = "0.0.0-rc-dev"

--- a/lookatme/__main__.py
+++ b/lookatme/__main__.py
@@ -160,7 +160,7 @@ def main(
 ):
     """lookatme - An interactive, terminal-based markdown presentation tool.
 
-    See https://lookatme.readthedocs.io/en/v{{VERSION}} for documentation
+    See https://lookatme.readthedocs.io/en/v0.0.0-rc-dev for documentation
     """
     lookatme.config.LOG = lookatme.log.create_log(log_path)
     if debug:

--- a/lookatme/contrib/file_loader.py
+++ b/lookatme/contrib/file_loader.py
@@ -64,12 +64,16 @@ class FileSchema(Schema):
         res = super(self.__class__, self).loads(*args, **kwargs)
         if res is None:
             raise ValueError("Could not loads")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
         return res
 
     def load(self, *args, **kwargs) -> Dict:
         res = super(self.__class__, self).load(*args, **kwargs)
         if res is None:
             raise ValueError("Could not load")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
         return res
 
 

--- a/lookatme/contrib/terminal.py
+++ b/lookatme/contrib/terminal.py
@@ -58,12 +58,16 @@ class TerminalExSchema(Schema):
         res = super(self.__class__, self).loads(*args, **kwargs)
         if res is None:
             raise ValueError("Could not loads")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
         return res
 
     def load(self, *args, **kwargs) -> Dict:
         res = super(self.__class__, self).load(*args, **kwargs)
         if res is None:
             raise ValueError("Could not load")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
         return res
 
 

--- a/lookatme/render/markdown_block.py
+++ b/lookatme/render/markdown_block.py
@@ -641,6 +641,15 @@ def render_fence(token: Dict, ctx: Context):
     ctx.widget_add(code)
 
 
+@contrib_first
+def render_code_block(token: Dict, ctx: Context):
+    """Render a code_block - text that is indented four spaces.
+    """
+    lang = codeblock.guess_lang(token["content"])
+    token["info"] = lang
+    render_fence(token, ctx)
+
+
 class TableTokenExtractor:
     def __init__(self):
         self.root = {"children": []}

--- a/lookatme/render/markdown_block.py
+++ b/lookatme/render/markdown_block.py
@@ -643,8 +643,7 @@ def render_fence(token: Dict, ctx: Context):
 
 @contrib_first
 def render_code_block(token: Dict, ctx: Context):
-    """Render a code_block - text that is indented four spaces.
-    """
+    """Render a code_block - text that is indented four spaces."""
     lang = codeblock.guess_lang(token["content"])
     token["info"] = lang
     render_fence(token, ctx)

--- a/lookatme/schemas.py
+++ b/lookatme/schemas.py
@@ -635,11 +635,13 @@ class MetaSchema(Schema):
 
         return res
 
-    def loads_partial_styles(self, *args, **kwargs):
+    def loads_partial_styles(self, *args, **kwargs) -> Dict:
         kwargs["partial"] = True
         res = super(self.__class__, self).loads(*args, **kwargs)
         if res is None:
             raise ValueError("Could not loads")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
 
         res = self._ensure_top_level_defaults(res)
         return res
@@ -648,6 +650,8 @@ class MetaSchema(Schema):
         res = super(self.__class__, self).loads(*args, **kwargs)
         if res is None:
             raise ValueError("Could not loads")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
 
         return res
 
@@ -656,6 +660,8 @@ class MetaSchema(Schema):
         res = super(self.__class__, self).load(*args, **kwargs)
         if res is None:
             raise ValueError("Could not loads")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
 
         res = self._ensure_top_level_defaults(res)
         return res
@@ -664,6 +670,8 @@ class MetaSchema(Schema):
         res = super(self.__class__, self).load(*args, **kwargs)
         if res is None:
             raise ValueError("Could not load")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
 
         return res
 
@@ -671,4 +679,7 @@ class MetaSchema(Schema):
         res = super(self.__class__, self).dump(*args, **kwargs)
         if res is None:
             raise ValueError("Could not dump")
+        if not isinstance(res, dict):
+            raise ValueError("Expected a dict")
+
         return res

--- a/lookatme/tutorial.py
+++ b/lookatme/tutorial.py
@@ -109,7 +109,7 @@ class Tutor:
         _, lineno = inspect.getsourcelines(self.impl_fn)
 
         version = "v" + lookatme.VERSION
-        if version == "v{{VERSION}}":
+        if version == "v0.0.0-rc-dev":
             version = "main"
 
         return "[{module}.{fn_name}]({link})".format(

--- a/lookatme/widgets/codeblock.py
+++ b/lookatme/widgets/codeblock.py
@@ -31,16 +31,19 @@ AVAILABLE_LEXERS = set()
 def guess_lang(content: str) -> str:
     if content.startswith("#!"):
         lexer = pygments.lexers.guess_lexer(content)
-        if "text" not in lexer.aliases:
-            return lexer.aliases[0]
-    
+        if "text" not in lexer.aliases:  # type: ignore
+            return lexer.aliases[0]  # type: ignore
+
     lang = "text"
 
-    curly_braces = re.search(r'[\{\}]', content) is not None
-    variable_assign = re.search(r'[a-zA-Z_0-9]+\s*=\s*[^=$]', content) is not None
-    pointers = re.search(r'[a-zA-Z_0-9]->[a-zA-Z0-9_]', content) is not None
-    def_functions = re.search(r'\s*def [a-zA-Z0-9_]+', content) is not None
-    function_calls = re.search(r'[a-zA-Z0-9_]+\s*([^)]+)', content, re.MULTILINE|re.DOTALL) is not None
+    curly_braces = re.search(r"[\{\}]", content) is not None
+    variable_assign = re.search(r"[a-zA-Z_0-9]+\s*=\s*[^=$]", content) is not None
+    pointers = re.search(r"[a-zA-Z_0-9]->[a-zA-Z0-9_]", content) is not None
+    def_functions = re.search(r"\s*def [a-zA-Z0-9_]+", content) is not None
+    function_calls = (
+        re.search(r"[a-zA-Z0-9_]+\s*([^)]+)", content, re.MULTILINE | re.DOTALL)
+        is not None
+    )
 
     if curly_braces or variable_assign or function_calls:
         lang = "javascript"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open(readme_path, "r") as f:
 
 setup(
     name="lookatme",
-    version="{{VERSION}}",
+    version="0.0.0-rc-dev",
     description="An interactive, command-line presentation tool",
     author="James Johnson",
     author_email="d0c.s4vage@gmail.com",

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -140,27 +140,20 @@ def test_lheading_levels(style):
     utils.validate_render(
         md_text=r"""
             H1
-            --
-
-            H2
             ==
 
-            H3
-            ##
+            H2
+            --
         """,
         text=[
-            "|H1|    ",
-            "        ",
-            ">>H2<<  ",
-            "        ",
-            "[[[H3]]]",
+            "|H1|  ",
+            "      ",
+            ">>H2<<",
         ],
         style_mask=[
-            "HHHH////",
-            "////////",
-            "hhhhhh//",
-            "////////",
-            "aaaaaaaa",
+            "HHHH//",
+            "//////",
+            "hhhhhh",
         ],
         styles={
             "H": style["headings"]["1"],

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -679,7 +679,7 @@ def test_code_block(styles):
             "NNNNNNNNNNNNNNNNNNNN",
             "NNNNNNNNNNNNNNNNNNNN",
             "KKKrFFFFFFFFrrrBBBBB",
-            'rrrrrrrrrrSSSSSSSSSr',
+            "rrrrrrrrrrSSSSSSSSSr",
         ],
         styles={
             "N": {},

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -107,6 +107,72 @@ def test_heading_levels(style):
 
 @override_style(
     {
+        "headings": {
+            "default": {
+                "fg": "bold",
+                "bg": "",
+                "prefix": ".",
+                "suffix": ".",
+            },
+            "1": {
+                "fg": "bold",
+                "bg": "",
+                "prefix": "|",
+                "suffix": "|",
+            },
+            "2": {
+                "fg": "italics",
+                "bg": "",
+                "prefix": ">>",
+                "suffix": "<<",
+            },
+            "3": {
+                "fg": "underline",
+                "bg": "",
+                "prefix": "[[[",
+                "suffix": "]]]",
+            },
+        },
+    }
+)
+def test_lheading_levels(style):
+    """Test basic header rendering"""
+    utils.validate_render(
+        md_text=r"""
+            H1
+            --
+
+            H2
+            ==
+
+            H3
+            ##
+        """,
+        text=[
+            "|H1|    ",
+            "        ",
+            ">>H2<<  ",
+            "        ",
+            "[[[H3]]]",
+        ],
+        style_mask=[
+            "HHHH////",
+            "////////",
+            "hhhhhh//",
+            "////////",
+            "aaaaaaaa",
+        ],
+        styles={
+            "H": style["headings"]["1"],
+            "h": style["headings"]["2"],
+            "a": style["headings"]["3"],
+            "/": {},
+        },
+    )
+
+
+@override_style(
+    {
         "table": {
             "column_spacing": 1,
             "header_divider": {"text": "-"},
@@ -589,6 +655,46 @@ def test_code(styles):
         ],
         styles={
             "R": {"fg": "#e6db74", "bg": "#272822"},
+            " ": {},
+        },
+    )
+
+
+@override_style(
+    {
+        "code": {
+            "style": "monokai",
+        }
+    }
+)
+def test_code_block(styles):
+    """Test code block (indented text) rendering"""
+    utils.validate_render(
+        md_text="""
+        test
+
+            def function():
+                print("testing")
+        """,
+        text=[
+            "test                ",
+            "                    ",
+            "def function():     ",
+            '    print("testing")',
+        ],
+        style_mask=[
+            "NNNNNNNNNNNNNNNNNNNN",
+            "NNNNNNNNNNNNNNNNNNNN",
+            "KKKrFFFFFFFFrrrBBBBB",
+            'rrrrrrrrrrSSSSSSSSSr',
+        ],
+        styles={
+            "N": {},
+            "K": {"fg": "#66d9ef", "bg": "#272822"},
+            "r": {"fg": "#f8f8f2", "bg": "#272822"},
+            "F": {"fg": "#a6e22e", "bg": "#272822"},
+            "B": {"bg": "#272822"},
+            "S": {"fg": "#e6db74", "bg": "#272822"},
             " ": {},
         },
     )


### PR DESCRIPTION
Adds tests/support for indented code blocks and setext-style headings.

Also changes the placeholder for the version number to v0.0.0-rc-dev so that it can be installed from source with the latest versions of pip.