### PR TITLE
Handle empty slides

### DIFF
--- a/lookatme/tui.py
+++ b/lookatme/tui.py
@@ -239,6 +239,15 @@ class SlideRenderer(threading.Thread):
     def _render_tokens(self, tokens):
         tmp_listbox = urwid.ListBox([])
 
+        if len(tokens) == 0:
+            tokens = [
+                {
+                    "type": "inline",
+                    "map": [0, 0],
+                    "children": [{"type": "text", "content": " ", "map": [0, 0]}],
+                }
+            ]
+
         self.ctx.clean_state_snapshot()
 
         with self.ctx.use_tokens(tokens):

--- a/tests/test_slides.py
+++ b/tests/test_slides.py
@@ -374,3 +374,93 @@ Hi\
             "G": style["scrollbar"]["gutter"],
         },
     )
+
+
+@override_style(
+    {
+        "slides": {
+            "fg": "#ff0000",
+            "bg": "#00ffff",
+        },
+        "title": {
+            "fg": "#111100",
+            "bg": "#001111",
+        },
+        "slide_number": {
+            "fg": "#222200",
+            "bg": "#002222",
+        },
+        "author": {
+            "fg": "#333300",
+            "bg": "#003333",
+        },
+        "date": {
+            "fg": "#444400",
+            "bg": "#004444",
+        },
+        "margin": {
+            "top": 0,
+            "bottom": 0,
+            "left": 0,
+            "right": 0,
+        },
+        "padding": {
+            "top": 1,
+            "bottom": 1,
+            "left": 1,
+            "right": 1,
+        },
+    }
+)
+def test_empty_slides(style):
+    meta = {
+        "title": "title",
+        "date": "DATE",
+        "author": "me",
+        "styles": style,
+    }
+    md = r"""
+---
+{}
+---
+    """.format(
+        yaml.dump(meta)
+    )
+    utils.validate_render(
+        as_slide=True,
+        render_width=30,
+        render_height=9,
+        md_text=md,
+        text=[
+            "             title            ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "me DATE            slide 1 / 1",
+        ],
+        style_mask=[
+            "_____________TTTTT____________",
+            "______________________________",
+            "______________________________",
+            "______________________________",
+            "______________________________",
+            "______________________________",
+            "______________________________",
+            "______________________________",
+            "AA_DDDD____________SSSSSSSSSSS",
+        ],
+        styles={
+            "T": style["title"],
+            "s": style["slides"],
+            "A": style["author"],
+            "D": style["date"],
+            "S": style["slide_number"],
+            "_": style["slides"],
+            "L": style["scrollbar"]["slider"],
+            "G": style["scrollbar"]["gutter"],
+        },
+    )


### PR DESCRIPTION
Fixes errors that occur when lookatme attempts to render empty markdown content.