### PR TITLE
fix attribute error related to pygments

### DIFF
--- a/lookatme/render/pygments.py
+++ b/lookatme/render/pygments.py
@@ -69,7 +69,7 @@ def render_text(text, lang="text", style_name=None, plain=False):
     markup = []
     for x in formatter.formatgenerator(code_tokens):
         if style_bg:
-            x[0].background = style_bg
+            x = (x[0].copy_modified(bg=style_bg), x[1])
         markup.append(x)
 
     if markup[-1][1] == "\n":


### PR DESCRIPTION
Hi, 
this fixes the issue discussed in https://github.com/d0c-s4vage/lookatme/issues/224 related to https://github.com/d0c-s4vage/lookatme/blob/c05abe1804d93254e9139039937eed43fb6b49ab/lookatme/render/pygments.py#L72.
The `background` attribute in the `urwid.AttrSpec` class is now a property. To modify it we need to create a copy of the object with `urwid.AttrSpec.copy_modified`.